### PR TITLE
now no need to magic value for n_stops

### DIFF
--- a/client.c
+++ b/client.c
@@ -23,12 +23,17 @@ static void client_task (void *args, zctx_t *ctx, void *pipe) {
     uint32_t rc = zsocket_connect (sock, CLIENT_ENDPOINT);
     assert (rc == 0);
     uint32_t request_count = 0;
+
+    // load transit data from disk
+    tdata_t tdata;
+    tdata_load(RRRR_INPUT_FILE, &tdata);
+
     while (true) {
         router_request_t req;
         router_request_initialize (&req);
         // unfortunately tdata is not available here or we could initialize from current epoch time
         if (randomize) 
-            router_request_randomize (&req);
+            router_request_randomize (&req, &tdata);
         else {
             req.from=from_s;
             req.to=to_s;

--- a/otp_api.c
+++ b/otp_api.c
@@ -203,7 +203,7 @@ static void send_request (int nc, void *broker_socket) {
     qstring += 1; // skip question mark
     router_request_t req;
     router_request_initialize (&req);
-    router_request_randomize (&req); // This prevents segfaults because data is not initialised
+    router_request_randomize (&req, &tdata); // This prevents segfaults because data is not initialised
     parse_request_from_qstring(&req, &tdata, &hash_grid, qstring);
     zmsg_t *msg = zmsg_new ();
     zmsg_pushmem (msg, &req, sizeof(req));

--- a/parse.c
+++ b/parse.c
@@ -19,7 +19,7 @@ void parse_request(router_request_t *req, tdata_t *tdata, HashGrid *hg, int opt,
         break;
     case 'r':
         srand(time(NULL));
-        router_request_randomize(req);
+        router_request_randomize(req, tdata);
         break;
     case 'D':
         {

--- a/router.c
+++ b/router.c
@@ -1028,11 +1028,11 @@ void router_request_from_epoch(router_request_t *req, tdata_t *tdata, time_t epo
     req->day_mask = 1 << cal_day;    
 }
 
-void router_request_randomize (router_request_t *req) {
+void router_request_randomize (router_request_t *req, tdata_t *tdata) {
     req->walk_speed = 1.5; // m/sec
     req->walk_slack = RRRR_WALK_SLACK_SEC; // sec
-    req->from = rrrrandom(6600); // 6600 for PDX, 70000 for NL
-    req->to = rrrrandom(6600);
+    req->from = rrrrandom(tdata->n_stops);
+    req->to = rrrrandom(tdata->n_stops);
     req->time = RTIME_ONE_DAY + SEC_TO_RTIME(3600 * 9 + rrrrandom(3600 * 12));
     req->via = NONE;
     req->arrive_by = rrrrandom(2); // 0 or 1

--- a/router.h
+++ b/router.h
@@ -138,7 +138,7 @@ void router_request_dump(router_t*, router_request_t*);
 
 void router_request_initialize(router_request_t*);
 
-void router_request_randomize(router_request_t*);
+void router_request_randomize(router_request_t*, tdata_t *tdata);
 
 bool router_request_reverse(router_t*, router_request_t*);
 

--- a/tests/test_speed.c
+++ b/tests/test_speed.c
@@ -66,7 +66,7 @@ START_TEST (test_speed_random) {
     for (int i = 0; i < N_REQUESTS; ++i) {
         printf (".");
         fflush (stdout);
-        router_request_randomize (&req);
+        router_request_randomize (&req, &tdata);
         stats_begin_clock ();
         router_route (&router, &req);
         stats_end_record ();


### PR DESCRIPTION
This is small fix, but it helps us to use the testerrrr with the -r param which we occasionally use.
