### PR TITLE
Implemented cancelable rounded router.

### DIFF
--- a/router.c
+++ b/router.c
@@ -306,6 +306,18 @@ tdata_stoptime (tdata_t* tdata, trip_t *trip, uint32_t route_stop, bool arrive, 
 }
 
 bool router_route(router_t *router, router_request_t *req) {
+    bool res = router_route_in_rounds(router, req);
+    if (res != true)
+        return result;
+
+    // Iterate over rounds. In round N, we have made N transfers.
+    for (uint8_t round = 0; round < router->n_rounds; ++round) {  // < n_rounds to apply upper bound on transfers...
+        router_round(router, req, round);
+    } // end for (round)
+    return true;
+}
+
+bool router_route_in_rounds(router_t *router, router_request_t *req) {
     // router_request_dump(router, preq);
     uint32_t n_stops = router->tdata->n_stops;
     router->day_mask = req->day_mask;
@@ -451,10 +463,8 @@ bool router_route(router_t *router, router_request_t *req) {
     if (n_rounds > RRRR_MAX_ROUNDS)
         n_rounds = RRRR_MAX_ROUNDS;
 
-    // Iterate over rounds. In round N, we have made N transfers.
-    for (uint8_t round = 0; round < n_rounds; ++round) {  // < n_rounds to apply upper bound on transfers...
-        router_round(router, req, round);
-    } // end for (round)
+    router->n_rounds = n_rounds;
+
     return true;
 }
 

--- a/router.h
+++ b/router.h
@@ -52,6 +52,12 @@ struct router {
     calendar_t day_mask;
     serviceday_t servicedays[3];
     // We should move more routing state in here, like round and sub-scratch pointers.
+
+    /* Store the number of rounds. The callee is responsible for calling the
+     * _round function this many times. If it stops doing that, the request
+     * is "cancelled". Obviously, it needs to be "cancelled" by inter-thread
+     * communication that is out of the scope of this library. */
+    uint32_t n_rounds;
 };
 
 
@@ -164,6 +170,9 @@ void router_request_next(router_request_t *req);
 void router_teardown(router_t*);
 
 bool router_route(router_t*, router_request_t*);
+
+/* Note that the callee is responsible for calling _round ->n_rounds times. */
+bool router_route_in_rounds(router_t*, router_request_t*);
 
 void router_round(router_t *router, router_request_t *req, uint8_t round);
 


### PR DESCRIPTION
- I created a new function router_route_in_rounds that _won't_ execute the _round calls (yes, it's a feature). Instead, the callee is responsible for that. This enables (app) developers to cancel a route request (just don't call _round anymore when the request is cancelled).
