### PR TITLE
Migrate unittest from master to ansi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(ansi)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wall -ansi -pedantic")
 
@@ -45,3 +46,5 @@ link_libraries(m)
 link_libraries(protobuf-c)
 
 add_executable(ansi ${SOURCE_FILES})
+
+add_subdirectory(tests)

--- a/bitset.h
+++ b/bitset.h
@@ -70,10 +70,12 @@ bool bitset_get(BitSet *self, uint32_t index);
  */
 uint32_t bitset_next_set_bit(BitSet*, uint32_t index);
 
+#ifdef RRRR_DEBUG
 /* Print a string-representation of this bitset to STDERR */
 void bitset_dump(BitSet *self);
 /* Return an enumeration of all the indices set in the BitSet */
 uint32_t bitset_enumerate(BitSet *self);
+#endif /* RRRR_DEBUG */
 
 #endif /* _BITSET_H */
 

--- a/bitset.h
+++ b/bitset.h
@@ -36,26 +36,43 @@ struct bitset_s {
     uint32_t capacity;
 };
 
+/* Allocate a new bitset of the specified capacity,
+ * and return a pointer to the BitSet struct.
+ */
 BitSet *bitset_new(uint32_t capacity);
 
+/* De-allocate a BitSet struct as well as the memory it references
+ * internally for the bit fields.
+ */
 void bitset_destroy(BitSet *self);
 
+/* Perform a logical AND on this BitSet using the given mask
+*/
 void bitset_mask_and(BitSet *self, BitSet *mask);
 
+/* Set all indices in this BitSet to true. */
 void bitset_black(BitSet *self);
 
+/* Unset all indices in this BitSet. */
 void bitset_clear(BitSet *self);
 
+/* Set specified index in this BitSet. */
 void bitset_set(BitSet *self, uint32_t index);
 
+/* Unset specified index in this BitSet. */
 void bitset_unset(BitSet *self, uint32_t index);
 
+/* Return whether the specified index is set in this BitSet */
 bool bitset_get(BitSet *self, uint32_t index);
 
+/* Return the next set index in this BitSet equal or greater than
+ * the specified index. Returns BITSET_NONE if there are no more set bits.
+ */
 uint32_t bitset_next_set_bit(BitSet*, uint32_t index);
 
+/* Print a string-representation of this bitset to STDERR */
 void bitset_dump(BitSet *self);
-
+/* Return an enumeration of all the indices set in the BitSet */
 uint32_t bitset_enumerate(BitSet *self);
 
 #endif /* _BITSET_H */

--- a/cmake_modules/FindCheck.cmake
+++ b/cmake_modules/FindCheck.cmake
@@ -1,0 +1,54 @@
+# - Try to find the CHECK libraries
+#  Once done this will define
+#
+#  CHECK_FOUND - system has check
+#  CHECK_INCLUDE_DIRS - the check include directory
+#  CHECK_LIBRARIES - check library
+#  
+#  Copyright (c) 2007 Daniel Gollub <gollub@b1-systems.de>
+#  Copyright (c) 2007-2009 Bjoern Ricks  <bjoern.ricks@gmail.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+
+INCLUDE( FindPkgConfig )
+
+IF ( Check_FIND_REQUIRED )
+	SET( _pkgconfig_REQUIRED "REQUIRED" )
+ELSE( Check_FIND_REQUIRED )
+	SET( _pkgconfig_REQUIRED "" )	
+ENDIF ( Check_FIND_REQUIRED )
+
+IF ( CHECK_MIN_VERSION )
+	PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check>=${CHECK_MIN_VERSION} )
+ELSE ( CHECK_MIN_VERSION )
+	PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check )
+ENDIF ( CHECK_MIN_VERSION )
+
+# Look for CHECK include dir and libraries
+IF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+
+	FIND_PATH( CHECK_INCLUDE_DIRS check.h )
+
+	FIND_LIBRARY( CHECK_LIBRARIES NAMES check )
+
+	IF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+		SET( CHECK_FOUND 1 )
+		IF ( NOT Check_FIND_QUIETLY )
+			MESSAGE ( STATUS "Found CHECK: ${CHECK_LIBRARIES}" )
+		ENDIF ( NOT Check_FIND_QUIETLY )
+	ELSE ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+		IF ( Check_FIND_REQUIRED )
+			MESSAGE( FATAL_ERROR "Could NOT find CHECK" )
+		ELSE ( Check_FIND_REQUIRED )
+			IF ( NOT Check_FIND_QUIETLY )
+				MESSAGE( STATUS "Could NOT find CHECK" )	
+			ENDIF ( NOT Check_FIND_QUIETLY )
+		ENDIF ( Check_FIND_REQUIRED )
+	ENDIF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+ENDIF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+
+# Hide advanced variables from CMake GUIs
+MARK_AS_ADVANCED( CHECK_INCLUDE_DIRS CHECK_LIBRARIES )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+ENABLE_TESTING()
+find_package(Check REQUIRED)
+include_directories(${CHECK_INCLUDE_DIRS})
+set(LIBS ${LIBS} ${CHECK_LIBRARIES})
+include_directories(. ..)
+
+set(SOURCE_FILES
+    ../bitset.c
+    ../bitset.h
+    run_tests.c
+    test_bitset.c
+    #test_hashgrid.c
+    #test_radixtree.c
+    )
+
+add_executable(tests ${SOURCE_FILES})
+SET_TARGET_PROPERTIES(tests PROPERTIES
+  COMPILE_FLAGS "-DRRRR_DEBUG ${SHARED_FLAGS}"
+)
+target_link_libraries(tests ${LIBS} pthread)
+add_test(tests ${CMAKE_CURRENT_BINARY_DIR}/tests)

--- a/tests/run_tests.c
+++ b/tests/run_tests.c
@@ -1,0 +1,26 @@
+#include <check.h>
+#include <stdlib.h>
+
+// could be in a header, but simpler here
+Suite *make_bitset_suite (void);
+//Suite *make_hashgrid_suite (void);
+//Suite *make_radixtree_suite (void);
+Suite *make_master_suite (void) {
+    Suite *s = suite_create ("Master");
+    return s;
+}
+
+int main (void) {
+    int number_failed;
+    SRunner *sr;
+    sr = srunner_create (make_master_suite ());
+    srunner_add_suite (sr, make_bitset_suite ());
+    //srunner_add_suite (sr, make_hashgrid_suite ());
+    //srunner_add_suite (sr, make_radixtree_suite ());
+    srunner_set_log (sr, "test.log");
+    srunner_run_all (sr, CK_VERBOSE); // CK_NORMAL
+    number_failed = srunner_ntests_failed (sr);
+    srunner_free (sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+

--- a/tests/test_bitset.c
+++ b/tests/test_bitset.c
@@ -23,7 +23,6 @@ START_TEST (test_bitset)
                 ck_assert(!bitset_get(bs, i));
             }
         }
-
         ck_assert(bitset_get(bs, 0));
         ck_assert(!bitset_get(bs, 1));
         ck_assert_int_eq(2, bitset_next_set_bit(bs, 1));
@@ -42,6 +41,29 @@ START_TEST (test_bitset)
         for (i = 0; i < 50000; ++i){
             ck_assert(!bitset_get(bs, i));
         }
+
+        //Test flipping all bits on
+        bitset_black(bs);
+        for (i = 0; i < 50000; ++i){
+            ck_assert(bitset_get(bs, i));
+        }
+
+        //Test clearing all bits
+        bitset_clear(bs);
+        ck_assert_int_eq(BITSET_NONE,bitset_next_set_bit(bs, 0));
+
+        //Test unset
+        bitset_black(bs);
+        for (i = 0; i < 50000; i += 2)
+            bitset_unset(bs, i);
+
+        ck_assert(!bitset_get(bs, 0));
+        ck_assert(bitset_get(bs, 1));
+        ck_assert_int_eq(1, bitset_next_set_bit(bs, 1));
+        ck_assert_int_eq(3, bitset_next_set_bit(bs, 2));
+        ck_assert_int_eq(BITSET_NONE, bitset_next_set_bit(bs, 50000));
+        ck_assert_int_eq(BITSET_NONE, bitset_next_set_bit(bs, 50001));
+
         bitset_destroy(bs);
         bitset_destroy(bs_inv);
     }

--- a/tests/test_bitset.c
+++ b/tests/test_bitset.c
@@ -1,0 +1,85 @@
+#include <check.h>
+#include <stdlib.h>
+#include "../bitset.h"
+
+START_TEST (test_bitset)
+    {
+        uint32_t i;
+        uint32_t max = 50000;
+        BitSet *bs = bitset_new(max);
+        BitSet *bs_inv = bitset_new(max);
+
+        for (i = 0; i < 50000; i += 2)
+            bitset_set(bs, i);
+        for (i = 1; i < 50000; i += 2)
+            bitset_set(bs_inv, i);
+
+        for (i = 0; i < 50000; ++i){
+            if (i % 2 == 0){
+                ck_assert(bitset_get(bs, i));
+                ck_assert(!bitset_get(bs_inv, i));
+            }else{
+                ck_assert(bitset_get(bs_inv, i));
+                ck_assert(!bitset_get(bs, i));
+            }
+        }
+
+        ck_assert(bitset_get(bs, 0));
+        ck_assert(!bitset_get(bs, 1));
+        ck_assert_int_eq(2, bitset_next_set_bit(bs, 1));
+        ck_assert_int_eq(0, bitset_next_set_bit(bs, 0));
+        ck_assert_int_eq(BITSET_NONE, bitset_next_set_bit(bs, 50000));
+        ck_assert_int_eq(BITSET_NONE, bitset_next_set_bit(bs, 50001));
+
+        ck_assert(!bitset_get(bs_inv, 0));
+        ck_assert(bitset_get(bs_inv, 1));
+        ck_assert_int_eq(1, bitset_next_set_bit(bs_inv, 1));
+        ck_assert_int_eq(3, bitset_next_set_bit(bs_inv, 2));
+        ck_assert_int_eq(BITSET_NONE, bitset_next_set_bit(bs_inv, 50000));
+        ck_assert_int_eq(BITSET_NONE, bitset_next_set_bit(bs_inv, 50001));
+
+        bitset_mask_and(bs, bs_inv);
+        for (i = 0; i < 50000; ++i){
+            ck_assert(!bitset_get(bs, i));
+        }
+        bitset_destroy(bs);
+        bitset_destroy(bs_inv);
+    }
+END_TEST
+
+Suite *make_bitset_suite(void) {
+    Suite *s = suite_create("BitSet");
+    TCase *tc_core = tcase_create("Core");
+    tcase_add_test  (tc_core, test_bitset);
+    suite_add_tcase(s, tc_core);
+    return s;
+}
+
+/*
+
+Enumerating very sparse 50kbit bitset 100k times:
+10.592 sec without skipping chunks == 0
+0.210 sec with skipping
+
+Enumerating very dense 50kbit bitset 100k times:
+20.525 sec without skipping
+20.599 sec with skipping
+
+So no real slowdown from skipping checks, but great improvement on sparse sets.
+Maybe switching to 32bit ints would allow finer-grained skipping.
+
+Why is the dense set so much slower? Probably function call overhead (1 per result). 
+For dense set:
+Adding inline keyword and -O2 reduces to 6.1 seconds.
+Adding inline keyword and -O3 reduces to 7.6 seconds (note this is higher than -O2).
+Adding -O2 without inline keyword reduces to 9.8 seconds.
+Adding -O3 without inline keyword reduces to 7.6 seconds.
+
+So enumerating the dense set 8 times takes roughly 0.0005 sec.
+
+For sparse set:
+Adding inline keyword and -O2 reduces to 0.064 seconds (0.641 sec for 1M enumerations).
+
+*/
+
+


### PR DESCRIPTION
- Add check as dependency
- Add test to cmake
- Make test_bitset ansi-c compliant and extend test
- Mask enumerate and dump functions under the DEBUG flag
- Document bitset.h

//TODO test_hashgrid and test_radixtree
