### PR TITLE
Ansi searchcut

### DIFF
--- a/router.c
+++ b/router.c
@@ -678,7 +678,7 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
          serviceday <= router->servicedays + router->n_servicedays;
          ++serviceday) {
 
-        uint16_t i_vj_offset;
+        int32_t i_vj_offset;
 
         /* Check that this journey_pattern still has any vehicle_journeys
          * running on this day.

--- a/router.c
+++ b/router.c
@@ -695,9 +695,10 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
         if (*best_vj != NONE &&
             !(jp->min_time < (jp->max_time - RTIME_ONE_DAY))) break;
 
-        for (i_vj_offset = 0;
-             i_vj_offset < jp->n_vjs;
-             ++i_vj_offset) {
+        for (i_vj_offset = req->arrive_by ? jp->n_vjs - 1: 0;
+             req->arrive_by ? i_vj_offset >= 0
+                            : i_vj_offset < jp->n_vjs;
+             req->arrive_by ? --i_vj_offset : ++i_vj_offset) {
             rtime_t time;
 
             #ifdef RRRR_DEBUG
@@ -736,6 +737,11 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
             /* rtime overflow due to long overnight vehicle_journey's on day 2 */
             if (time == UNREACHED) continue;
 
+            if (req->arrive_by ? time < req->time_cutoff
+                               : time > req->time_cutoff){
+                goto end;
+            }
+
             /* Mark vj for boarding if it improves on the last round's
              * post-walk time at this stop. Note: we should /not/ be comparing
              * to the current best known time at this stop, because it may have
@@ -750,6 +756,8 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
             }
         }  /*  end for (vehicle_journey's within this route) */
     }  /*  end for (service days: yesterday, today, tomorrow) */
+    end:
+    return;
 }
 
 static bool

--- a/router.c
+++ b/router.c
@@ -739,7 +739,7 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
 
             if (req->arrive_by ? time < req->time_cutoff
                                : time > req->time_cutoff){
-                goto end;
+                return;
             }
 
             /* Mark vj for boarding if it improves on the last round's
@@ -753,12 +753,10 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
                 *best_vj = i_vj_offset;
                 *best_time = time;
                 *best_serviceday = serviceday;
-                goto end;
+                return;
             }
         }  /*  end for (vehicle_journey's within this route) */
     }  /*  end for (service days: yesterday, today, tomorrow) */
-    end:
-    return;
 }
 
 static bool

--- a/router.c
+++ b/router.c
@@ -753,6 +753,7 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
                 *best_vj = i_vj_offset;
                 *best_time = time;
                 *best_serviceday = serviceday;
+                goto end;
             }
         }  /*  end for (vehicle_journey's within this route) */
     }  /*  end for (service days: yesterday, today, tomorrow) */

--- a/router.c
+++ b/router.c
@@ -753,7 +753,10 @@ static void search_vehicle_journeys_within_days(router_t *router, router_request
                 *best_vj = i_vj_offset;
                 *best_time = time;
                 *best_serviceday = serviceday;
+/* BUG: GCC is significantly slower with this return, clang improves a lot. */
+#ifdef __clang__
                 return;
+#endif
             }
         }  /*  end for (vehicle_journey's within this route) */
     }  /*  end for (service days: yesterday, today, tomorrow) */


### PR DESCRIPTION
WARNING this assumes all trips are correctly ordered. Currently this will not properly work when realtime is switched on
