### PR TITLE
Fix build with new gtfs-realtime.proto

### DIFF
--- a/tdata_realtime_expanded.c
+++ b/tdata_realtime_expanded.c
@@ -331,8 +331,7 @@ static void tdata_realtime_journey_pattern_type(TransitRealtime__TripUpdate *rt_
          ++i_stu) {
         TransitRealtime__TripUpdate__StopTimeUpdate *rt_stop_time_update = rt_trip_update->stop_time_update[i_stu];
 
-        *changed_jp |= (rt_stop_time_update->schedule_relationship == TRANSIT_REALTIME__TRIP_UPDATE__STOP_TIME_UPDATE__SCHEDULE_RELATIONSHIP__ADDED ||
-                           rt_stop_time_update->schedule_relationship == TRANSIT_REALTIME__TRIP_UPDATE__STOP_TIME_UPDATE__SCHEDULE_RELATIONSHIP__SKIPPED);
+        *changed_jp |= (rt_stop_time_update->schedule_relationship == TRANSIT_REALTIME__TRIP_UPDATE__STOP_TIME_UPDATE__SCHEDULE_RELATIONSHIP__SKIPPED);
         *nodata_jp &= (rt_stop_time_update->schedule_relationship == TRANSIT_REALTIME__TRIP_UPDATE__STOP_TIME_UPDATE__SCHEDULE_RELATIONSHIP__NO_DATA);
 
         *n_sp += (rt_stop_time_update->schedule_relationship != TRANSIT_REALTIME__TRIP_UPDATE__STOP_TIME_UPDATE__SCHEDULE_RELATIONSHIP__SKIPPED &&


### PR DESCRIPTION
The removed attribute ADDED in TripUpdate in the GTFS specification caused a build error in tdata_realtime_expanded.c
See https://github.com/bliksemlabs/rrrr/commit/ea15a69d2ed32067d82ac3f34252aca161eb1ba4#diff-a405d2bd76f9fde04d450d18d45532ceL206 for the breaking change
and https://travis-ci.org/bliksemlabs/rrrr/jobs/51377118 for the compiler error
