### PR TITLE
Rrtimetable unittest

### DIFF
--- a/rrtimetable/rrtimetable/exporter/helper.py
+++ b/rrtimetable/rrtimetable/exporter/helper.py
@@ -1,3 +1,0 @@
-import os
-parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.sys.path.insert(0,parentdir)

--- a/rrtimetable/rrtimetable/exporter/timetable3.py
+++ b/rrtimetable/rrtimetable/exporter/timetable3.py
@@ -1,4 +1,3 @@
-import helper
 from utils import *
 import operator
 import sys

--- a/rrtimetable/rrtimetable/exporter/timetable4.py
+++ b/rrtimetable/rrtimetable/exporter/timetable4.py
@@ -1,4 +1,3 @@
-import helper
 from utils import *
 import operator
 import sys

--- a/rrtimetable/rrtimetable/tests/exportv3_tests.py
+++ b/rrtimetable/rrtimetable/tests/exportv3_tests.py
@@ -1,5 +1,4 @@
 import unittest
-import helper
 from model.transit import *
 from exporter.timetable3 import export
 import datetime

--- a/rrtimetable/rrtimetable/tests/exportv3_tests.py
+++ b/rrtimetable/rrtimetable/tests/exportv3_tests.py
@@ -7,7 +7,7 @@ import datetime
 class TestSequenceFunctions(unittest.TestCase):
 
     def test_integration(self):
-        tdata = Timetable(datetime.date(2014,1,1))
+        tdata = Timetable(datetime.date(2014,1,1),'Europe/Amsterdam')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam',name='SA1')
         sa = StopArea(tdata,'SA2','Europe/Amsterdam',name='SA2')
         sa = StopArea(tdata,'SA3','Europe/Amsterdam',name='SA3')
@@ -18,7 +18,7 @@ class TestSequenceFunctions(unittest.TestCase):
         conn = Connection(tdata,'SP2','SP1',120,type=2)
         conn = Connection(tdata,'SP3','SP2',120,type=2)
         conn = Connection(tdata,'SP2','SP3',120,type=2)
-        op = Operator(tdata,'OP1',name='Operator',url='http://www.example.com')
+        op = Operator(tdata,'OP1',name='Operator',url='http://www.example.com',timezone='Europe/Amsterdam')
         buspm = PhysicalMode(tdata,'3',name='Bus')
         buscc = CommercialMode(tdata,'3',name='Bus')
         l = Line(tdata,'L1','OP1','3',name='Testline',code='T')

--- a/rrtimetable/rrtimetable/tests/helper.py
+++ b/rrtimetable/rrtimetable/tests/helper.py
@@ -1,3 +1,0 @@
-import os
-parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-os.sys.path.insert(0,parentdir)

--- a/rrtimetable/rrtimetable/tests/model_tests.py
+++ b/rrtimetable/rrtimetable/tests/model_tests.py
@@ -1,25 +1,24 @@
 import unittest
-import helper
 from model.transit import *
 import datetime
 
 class TestSequenceFunctions(unittest.TestCase):
 
     def test_equal(self):
-        tdata = Timetable(datetime.date(2014,1,1))
+        tdata = Timetable(datetime.date(2014,1,1),'Europe/Amsterdam')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam',name='SA1')
         sa = StopArea(tdata,'SA2','Europe/Amsterdam',name='SA2')
         sa = StopArea(tdata,'SA3','Europe/Amsterdam',name='SA3')
         sp = StopPoint(tdata,'SP1','SA1',name='SP1')
         sp = StopPoint(tdata,'SP2','SA2',name='SP1')
         sp = StopPoint(tdata,'SP3','SA3',name='SP1')
-        
+
         jpp1 = JourneyPatternPoint(tdata,'SP1',forboarding=True,foralighting=True,timingpoint=False)
         jpp2 = JourneyPatternPoint(tdata,'SP1',forboarding=True,foralighting=True,timingpoint=False)
         self.assertEquals(jpp1,jpp2)
 
     def test_primary_key_constraints(self):
-        tdata = Timetable(datetime.date(2014,1,1))
+        tdata = Timetable(datetime.date(2014,1,1),'Europe/Amsterdam')
         pm = PhysicalMode(tdata,'BUS',name='Bus')
         cm = CommercialMode(tdata,'BUS',name='Bus')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam')
@@ -52,7 +51,7 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEquals(tdata.vehicle_journeys['VJ1'].route.line.operator.name,'OP1')
 
     def test_foreign_key_constraints(self):
-        tdata = Timetable(datetime.date(2014,1,1))
+        tdata = Timetable(datetime.date(2014,1,1),'Europe/Amsterdam')
         pm = PhysicalMode(tdata,'BUS',name='Bus')
         cm = CommercialMode(tdata,'BUS',name='Bus')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam')
@@ -77,7 +76,7 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEquals(tdata.vehicle_journeys['VJ1'].route.line.operator.name,'OP1')
 
     def test_integration(self):
-        tdata = Timetable(datetime.date(2014,1,1))
+        tdata = Timetable(datetime.date(2014,1,1),'Europe/Amsterdam')
         pm = PhysicalMode(tdata,'BUS',name='Bus')
         cm = CommercialMode(tdata,'BUS',name='Bus')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam',name='SA1')
@@ -131,7 +130,7 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEquals(3,len(tdata.timedemandgroups))
 
     def test_utc_dst_off_to_on(self):
-        tdata = Timetable(datetime.date(2015,3,28))
+        tdata = Timetable(datetime.date(2015,3,28),'Europe/Amsterdam')
         pm = PhysicalMode(tdata,'BUS',name='Bus')
         cm = CommercialMode(tdata,'BUS',name='Bus')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam',name='SA1')
@@ -170,7 +169,7 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEquals(set([1]),tdata.vehicle_journeys_utc[('VJ1',7200)].validity_pattern)
 
     def test_utc_dst_on_to_off(self):
-        tdata = Timetable(datetime.date(2015,10,24))
+        tdata = Timetable(datetime.date(2015,10,24),'Europe/Amsterdam')
         pm = PhysicalMode(tdata,'BUS',name='Bus')
         cm = CommercialMode(tdata,'BUS',name='Bus')
         sa = StopArea(tdata,'SA1','Europe/Amsterdam',name='SA1')

--- a/rrtimetable/rrtimetable/tests/util_tests.py
+++ b/rrtimetable/rrtimetable/tests/util_tests.py
@@ -1,5 +1,4 @@
 import unittest
-import helper
 from model.utils import *
 import datetime
 


### PR DESCRIPTION
Fixes the rrtimetable unittest and removes unnecessary helper.py

Unit tests can be run without the helper with the following commands from the rrtimetable directory:

```
python -m unittest discover . "*_tests.py" # for all tests
python -m unittest tests.exportv3_tests    # for specific test
```
