### PR TITLE
Fix router_route_first_departure()

### DIFF
--- a/api.c
+++ b/api.c
@@ -94,6 +94,7 @@ static bool search_streetnetwork(router_t *router, router_request_t *req){
  */
 bool router_route_first_departure (router_t *router, router_request_t *req, plan_t *plan) {
     router_reset (router);
+    search_streetnetwork(router,req);
 
     if ( ! router_route (router, req) ) {
         return false;


### PR DESCRIPTION
Added a missing call to search_streetnetwork() in router_route_first_departure()
