### PR TITLE
Fix hashgrid initialization

### DIFF
--- a/hashgrid.c
+++ b/hashgrid.c
@@ -5,6 +5,7 @@
 
 /* hashgrid.c */
 #include "hashgrid.h"
+#include "util.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -218,6 +219,7 @@ bool hashgrid_init (hashgrid_t *hg, uint32_t grid_dim, double bin_size_meters,
             for (x = 0; x < grid_dim; ++x) {
                 hg->bins[y * grid_dim + x] = bin;
                 bin += hg->counts[y * grid_dim + x];
+                bin = MIN(bin, hg->items + n_items - 1);
                 /* Reset bin item count for reuse when filling up bins. */
                 hg->counts[y * grid_dim + x] = 0;
             }

--- a/tests/test_hashgrid.c
+++ b/tests/test_hashgrid.c
@@ -43,12 +43,34 @@ START_TEST (test_hashgrid)
     }
 END_TEST
 
+START_TEST (test_hashgrid_init)
+    {
+        coord_t coords[2];
+        coord_from_lat_lon(&coords[0], 1.0, 1.0);
+        coord_from_lat_lon(&coords[1], 2.0, 2.0);
+
+        hashgrid_t hg;
+        hashgrid_result_t result;
+
+        hashgrid_init(&hg, 100, 500, coords, 2);
+        hashgrid_query (&hg, &result, coords[1], 500.0);
+
+        double distance = 0.0;
+        while(hashgrid_result_next_filtered(&result, &distance) != HASHGRID_NONE) {
+
+        }
+
+        hashgrid_teardown (&hg);
+    }
+END_TEST
+
 Suite *make_hashgrid_suite(void);
 
 Suite *make_hashgrid_suite(void) {
     Suite *s = suite_create("hashgrid");
     TCase *tc_core = tcase_create("Core");
     tcase_add_test  (tc_core, test_hashgrid);
+    tcase_add_loop_test  (tc_core, test_hashgrid_init, 0, 20);
     suite_add_tcase(s, tc_core);
     return s;
 }


### PR DESCRIPTION
In the hashgrid the hg->bins is an array of pointers to hg->items.
But due to a faulty initialization, the pointers in the highest bins
after the final item point (one) outside the range of the hg->items array.
If these bins are referenced a segfault can occur.

This change forces the bins pointers to stay within hg->items array.
